### PR TITLE
made CameraFlashOff as default to fix unresponsive first touch to toggle flash

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -15,8 +15,10 @@ typedef enum : NSUInteger {
 } CameraPosition;
 
 typedef enum : NSUInteger {
-    CameraFlashOn,
-    CameraFlashOff
+    // The default state has to be off
+    // FIXES: Unresposive first touch to toggle flash.
+    CameraFlashOff,
+    CameraFlashOn
 } CameraFlash;
 
 typedef enum : NSUInteger {


### PR DESCRIPTION
Thanks for the control. When i was playing with it today i found that it doesn't toggle the flash when i try it for the first time since it assume that the camera flash in on by default. so i went on to fix it.
