### PR TITLE
Handle disabled autorotation

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -537,7 +537,7 @@
 - (AVCaptureVideoOrientation)orientationForConnection
 {
     AVCaptureVideoOrientation videoOrientation = AVCaptureVideoOrientationPortrait;
-    switch (self.interfaceOrientation) {
+    switch ([[UIDevice currentDevice] orientation]) {
         case UIInterfaceOrientationLandscapeLeft:
             videoOrientation = AVCaptureVideoOrientationLandscapeLeft;
             break;


### PR DESCRIPTION
Sets the correct AVCaptureVideoOrientation by checking the
currentDevice orientation to support apps that have autorotation
disabled