### PR TITLE
Audio not recorded on videos longer than 10 seconds.

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -231,6 +231,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
             }
         
             _movieFileOutput = [[AVCaptureMovieFileOutput alloc] init];
+            [_movieFileOutput setMovieFragmentInterval:kCMTimeInvalid];
             if([self.session canAddOutput:_movieFileOutput]) {
                 [self.session addOutput:_movieFileOutput];
             }


### PR DESCRIPTION
Applying http://stackoverflow.com/questions/26735627/ios-8-ipad-avcapturemoviefileoutput-drops-loses-never-gets-audio-track-after fixes #49.