### PR TITLE
Fix video orientation if starting in landscape

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -214,6 +214,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
         
         if([self.session canAddInput:_videoDeviceInput]) {
             [self.session  addInput:_videoDeviceInput];
+			self.captureVideoPreviewLayer.connection.videoOrientation = [self orientationForConnection];
         }
         
         // add audio if video is enabled


### PR DESCRIPTION
Currently, if you start the controller when in landscape, the video has the wrong orientation. Once you rotate, everything is fine.

Added an extra set of the connection orientation on initialise, which fixes this issue.