### PR TITLE
fixed video orientation in saved output file

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -15,9 +15,7 @@
 @property (strong, nonatomic) AVCaptureStillImageOutput *stillImageOutput;
 @property (strong, nonatomic) AVCaptureSession *session;
 @property (strong, nonatomic) AVCaptureDevice *videoCaptureDevice;
-@property (strong, nonatomic) AVCaptureDevice *audioCaptureDevice;
 @property (strong, nonatomic) AVCaptureDeviceInput *videoDeviceInput;
-@property (strong, nonatomic) AVCaptureDeviceInput *audioDeviceInput;
 @property (strong, nonatomic) AVCaptureVideoPreviewLayer *captureVideoPreviewLayer;
 @property (strong, nonatomic) UITapGestureRecognizer *tapGesture;
 @property (strong, nonatomic) CALayer *focusBoxLayer;
@@ -138,25 +136,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
 - (void)start {
     [LLSimpleCamera requestCameraPermission:^(BOOL granted) {
         if(granted) {
-            // request microphone permission if video is enabled
-            if(self.videoEnabled) {
-                [LLSimpleCamera requestMicrophonePermission:^(BOOL granted) {
-                    if(granted) {
-                        [self initialize];
-                    }
-                    else {
-                        NSError *error = [NSError errorWithDomain:LLSimpleCameraErrorDomain
-                                                             code:LLSimpleCameraErrorCodeMicrophonePermission
-                                                         userInfo:nil];
-                        if(self.onError) {
-                            self.onError(self, error);
-                        }
-                    }
-                }];
-            }
-            else {
-                [self initialize];
-            }
+            [self initialize];
         }
         else {
             NSError *error = [NSError errorWithDomain:LLSimpleCameraErrorDomain
@@ -216,20 +196,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
             [self.session  addInput:_videoDeviceInput];
         }
         
-        // add audio if video is enabled
         if(self.videoEnabled) {
-            _audioCaptureDevice = [AVCaptureDevice defaultDeviceWithMediaType:AVMediaTypeAudio];
-            _audioDeviceInput = [AVCaptureDeviceInput deviceInputWithDevice:_audioCaptureDevice error:&error];
-            if (!_audioDeviceInput) {
-                if(self.onError) {
-                    self.onError(self, error);
-                }
-            }
-        
-            if([self.session canAddInput:_audioDeviceInput]) {
-                [self.session addInput:_audioDeviceInput];
-            }
-        
             _movieFileOutput = [[AVCaptureMovieFileOutput alloc] init];
             if([self.session canAddOutput:_movieFileOutput]) {
                 [self.session addOutput:_movieFileOutput];
@@ -759,18 +726,4 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     }
     
 }
-
-+ (void)requestMicrophonePermission:(void (^)(BOOL granted))completionBlock {
-    if([[AVAudioSession sharedInstance] respondsToSelector:@selector(requestRecordPermission:)]) {
-        [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-            // return to main thread
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if(completionBlock) {
-                    completionBlock(granted);
-                }
-            });
-        }];
-    }
-}
-
 @end

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -329,8 +329,28 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     if(self.flash == CameraFlashOn) {
         [self enableTorch:YES];
     }
-    [self.movieFileOutput startRecordingToOutputFileURL:url recordingDelegate:self];
-}
+    
+    // Capture all the open connections
+    AVCaptureConnection *videoConnection = nil;
+    
+    for ( AVCaptureConnection *connection in [self.movieFileOutput connections] )
+    {
+        for ( AVCaptureInputPort *port in [connection inputPorts] )
+        {
+            // get only the video media types
+            if ( [[port mediaType] isEqual:AVMediaTypeVideo] )
+            {
+                videoConnection = connection;
+            }
+        }
+    }
+    
+    if([videoConnection isVideoOrientationSupported]) // **Here it is, its always false**
+    {
+        [videoConnection setVideoOrientation:[[UIDevice currentDevice] orientation]];
+    }
+    
+    [self.movieFileOutput startRecordingToOutputFileURL:url recordingDelegate:self];}
 
 - (void)stopRecording:(void (^)(LLSimpleCamera *camera, NSURL *outputFileUrl, NSError *error))completionBlock {
     


### PR DESCRIPTION
Previously, when the video was saved to an output file, even though the view was responding correctly to the orientation changes, the output file's orientation was wrong (eg. when the camera was in landscape mode, the video was still being saved in portrait, causing the video to be playbacked at a 90 degree flip). 

Now, the movie is saved in the correct orientation to the output file.