### PR TITLE
Provide an option for camera mirror.

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -21,6 +21,13 @@ typedef enum : NSUInteger {
     CameraFlashAuto
 } CameraFlash;
 
+typedef enum : NSUInteger {
+    // The default state has to be off
+    CameraMirrorOff,
+    CameraMirrorOn,
+    CameraMirrorAuto
+} CameraMirror;
+
 extern NSString *const LLSimpleCameraErrorDomain;
 typedef enum : NSUInteger {
     LLSimpleCameraErrorCodeCameraPermission = 10,
@@ -51,6 +58,11 @@ typedef enum : NSUInteger {
  * Camera flash mode.
  */
 @property (nonatomic, readonly) CameraFlash flash;
+
+/**
+ * Camera mirror mode.
+ */
+@property (nonatomic) CameraMirror mirror;
 
 /**
  * Position of the camera.

--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -23,10 +23,10 @@ typedef enum : NSUInteger {
 
 typedef enum : NSUInteger {
     // The default state has to be off
-    CameraMirrorOff,
-    CameraMirrorOn,
-    CameraMirrorAuto
-} CameraMirror;
+    LLCameraMirrorOff,
+    LLCameraMirrorOn,
+    LLCameraMirrorAuto
+} LLCameraMirror;
 
 extern NSString *const LLSimpleCameraErrorDomain;
 typedef enum : NSUInteger {
@@ -62,7 +62,7 @@ typedef enum : NSUInteger {
 /**
  * Camera mirror mode.
  */
-@property (nonatomic) CameraMirror mirror;
+@property (nonatomic) LLCameraMirror mirror;
 
 /**
  * Position of the camera.

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -464,7 +464,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     }
 }
 
-- (void)setMirror:(CameraMirror)mirror
+- (void)setMirror:(LLCameraMirror)mirror
 {
     _mirror = mirror;
 
@@ -476,7 +476,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     AVCaptureConnection *pictureConnection = [_stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
 
     switch (mirror) {
-        case CameraMirrorOff: {
+        case LLCameraMirrorOff: {
             if ([videoConnection isVideoMirroringSupported]) {
                 [videoConnection setVideoMirrored:NO];
             }
@@ -487,7 +487,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
             break;
         }
 
-        case CameraMirrorOn: {
+        case LLCameraMirrorOn: {
             if ([videoConnection isVideoMirroringSupported]) {
                 [videoConnection setVideoMirrored:YES];
             }
@@ -498,7 +498,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
             break;
         }
 
-        case CameraMirrorAuto: {
+        case LLCameraMirrorAuto: {
             BOOL shouldMirror = (_position == LLCameraPositionFront);
             if ([videoConnection isVideoMirroringSupported]) {
                 [videoConnection setVideoMirrored:shouldMirror];
@@ -579,7 +579,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     self.videoCaptureDevice = device;
     self.videoDeviceInput = videoInput;
 
-    if (_position == CameraPositionFront) {
+    if (_position == LLCameraPositionFront) {
         AVCaptureConnection *videoConnection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
         if ([videoConnection isVideoMirroringSupported]) {
             [videoConnection setVideoMirrored:YES];

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -55,6 +55,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
         _tapToFocus = YES;
         _useDeviceOrientation = NO;
         _flash = CameraFlashOff;
+        _mirror = CameraMirrorAuto;
         _videoEnabled = videoEnabled;
         _recording = NO;
     }
@@ -477,6 +478,55 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     }
 }
 
+- (void)setMirror:(CameraMirror)mirror {
+    _mirror = mirror;
+
+    if(!self.session) {
+        return;
+    }
+
+    AVCaptureConnection *videoConnection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
+    AVCaptureConnection *pictureConnection = [_stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
+
+    switch (mirror) {
+        case CameraMirrorOff: {
+            if ([videoConnection isVideoMirroringSupported]) {
+                [videoConnection setVideoMirrored:NO];
+            }
+            
+            if ([pictureConnection isVideoMirroringSupported]) {
+                [pictureConnection setVideoMirrored:NO];
+            }
+            break;
+        }
+
+        case CameraMirrorOn: {
+            if ([videoConnection isVideoMirroringSupported]) {
+                [videoConnection setVideoMirrored:YES];
+            }
+            
+            if ([pictureConnection isVideoMirroringSupported]) {
+                [pictureConnection setVideoMirrored:YES];
+            }
+            break;
+        }
+
+        case CameraMirrorAuto: {
+            BOOL shouldMirror = (_position == CameraPositionFront);
+            if ([videoConnection isVideoMirroringSupported]) {
+                [videoConnection setVideoMirrored:shouldMirror];
+            }
+            
+            if ([pictureConnection isVideoMirroringSupported]) {
+                [pictureConnection setVideoMirrored:shouldMirror];
+            }
+            break;
+        }
+    }
+
+    return;
+}
+
 - (CameraPosition)togglePosition {
     if(!self.session) {
         return self.position;
@@ -534,6 +584,20 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     
     self.videoCaptureDevice = device;
     self.videoDeviceInput = videoInput;
+
+    if (_position == CameraPositionFront) {
+        AVCaptureConnection *videoConnection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
+        if ([videoConnection isVideoMirroringSupported]) {
+            [videoConnection setVideoMirrored:YES];
+        }
+
+        AVCaptureConnection *pictureConnection = [_stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
+        if ([pictureConnection isVideoMirroringSupported]) {
+            [pictureConnection setVideoMirrored:YES];
+        }
+    }
+
+    [self setMirror:_mirror];
 }
 
 

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -579,18 +579,6 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     self.videoCaptureDevice = device;
     self.videoDeviceInput = videoInput;
 
-    if (_position == LLCameraPositionFront) {
-        AVCaptureConnection *videoConnection = [_movieFileOutput connectionWithMediaType:AVMediaTypeVideo];
-        if ([videoConnection isVideoMirroringSupported]) {
-            [videoConnection setVideoMirrored:YES];
-        }
-
-        AVCaptureConnection *pictureConnection = [_stillImageOutput connectionWithMediaType:AVMediaTypeVideo];
-        if ([pictureConnection isVideoMirroringSupported]) {
-            [pictureConnection setVideoMirrored:YES];
-        }
-    }
-
     [self setMirror:_mirror];
 }
 


### PR DESCRIPTION
This PR will provide a new option for `CameraMirror`.

- Auto: Only set mirror on when using the front camera, this will make sure that the resulting media(video/picture) is flipped properly.
- On: Always mirror.
- Off: No mirror.