### PR TITLE
fix: Camera screen always remain in main-screen bounds instead of the…

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -102,11 +102,10 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
 
 - (void)attachToViewController:(UIViewController *)vc withFrame:(CGRect)frame
 {
-    [vc.view addSubview:self.view];
     [vc addChildViewController:self];
+    self.view.frame = frame;
+    [vc.view addSubview:self.view];
     [self didMoveToParentViewController:vc];
-    
-    vc.view.frame = frame;
 }
 
 - (void)start


### PR DESCRIPTION
Camera screen always remain in main-screen bounds instead of the parent controller screen