### PR TITLE
Clear session after stop

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -49,6 +49,11 @@ typedef enum : NSUInteger {
 @property (nonatomic, copy) void (^onError)(LLSimpleCamera *camera, NSError *error);
 
 /**
+ * Triggered when camera starts recording
+ */
+@property (nonatomic, copy) void (^onStartRecording)(LLSimpleCamera* camera);
+
+/**
  * Camera quality, set a constants prefixed with AVCaptureSessionPreset.
  * Make sure to call before calling -(void)initialize method, otherwise it would be late.
  */

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -404,6 +404,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
 - (void)captureOutput:(AVCaptureFileOutput *)captureOutput didStartRecordingToOutputFileAtURL:(NSURL *)fileURL fromConnections:(NSArray *)connections
 {
     self.recording = YES;
+    if(self.onStartRecording) self.onStartRecording(self);
 }
 
 - (void)captureOutput:(AVCaptureFileOutput *)captureOutput didFinishRecordingToOutputFileAtURL:(NSURL *)outputFileURL fromConnections:(NSArray *)connections error:(NSError *)error

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -295,6 +295,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
 - (void)stop
 {
     [self.session stopRunning];
+    self.session = nil;
 }
 
 


### PR DESCRIPTION
First of all, my congrats to this awesome library!

I'm starting a new app that is using your simple camera library. When the user opens the screen it should start the camera with video disabled at first. Current implementation doesn't allow to enable video in a latter time because it reuses the session.