### PR TITLE
Add Flag to use device orientation on capture

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -117,6 +117,12 @@ typedef enum : NSUInteger {
 @property (nonatomic) BOOL useDeviceOrientation;
 
 /**
+ * Set YES if you your view controller does not allow autorotation,
+ * but you want to use the devide orientation on capture. Enabled by default.
+ */
+@property (nonatomic) BOOL useDeviceOrientationOnCapture;
+
+/**
  * Use this method to request camera permission before initalizing LLSimpleCamera.
  */
 + (void)requestCameraPermission:(void (^)(BOOL granted))completionBlock;

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -74,7 +74,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     _fixOrientationAfterCapture = NO;
     _tapToFocus = YES;
     _useDeviceOrientation = NO;
-    _useDeviceOrientationOnCapture = YES;
+    _useDeviceOrientationOnCapture = NO;
     _flash = LLCameraFlashOff;
     _mirror = LLCameraMirrorAuto;
     _videoEnabled = videoEnabled;
@@ -384,7 +384,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
             // get only the video media types
             if ([[port mediaType] isEqual:AVMediaTypeVideo]) {
                 if([connection isVideoOrientationSupported]) {
-                    [connection setVideoOrientation:[self orientationForConnection:false]];
+                    [connection setVideoOrientation:[self orientationForConnection:true]];
                 }
             }
         }

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -319,6 +319,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     // freeze the screen
     [self.captureVideoPreviewLayer.connection setEnabled:NO];
     
+    __weak typeof(self) _self = self;
     [self.stillImageOutput captureStillImageAsynchronouslyFromConnection:videoConnection completionHandler: ^(CMSampleBufferRef imageSampleBuffer, NSError *error) {
          
          UIImage *image = nil;
@@ -335,10 +336,10 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
              image = [[UIImage alloc] initWithData:imageData];
              
              if(exactSeenImage) {
-                 image = [self cropImageUsingPreviewBounds:image];
+                 image = [_self cropImageUsingPreviewBounds:image];
              }
              
-             if(self.fixOrientationAfterCapture) {
+             if(_self.fixOrientationAfterCapture) {
                  image = [image fixOrientation];
              }
          }
@@ -346,7 +347,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
          // trigger the block
          if(onCapture) {
              dispatch_async(dispatch_get_main_queue(), ^{
-                onCapture(self, image, metadata, error);
+                onCapture(_self, image, metadata, error);
              });
          }
      }];

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -74,6 +74,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     _fixOrientationAfterCapture = NO;
     _tapToFocus = YES;
     _useDeviceOrientation = NO;
+    _useDeviceOrientationOnCapture = YES;
     _flash = LLCameraFlashOff;
     _mirror = LLCameraMirrorAuto;
     _videoEnabled = videoEnabled;
@@ -250,7 +251,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
         
         if([self.session canAddInput:_videoDeviceInput]) {
             [self.session  addInput:_videoDeviceInput];
-			self.captureVideoPreviewLayer.connection.videoOrientation = [self orientationForConnection];
+            self.captureVideoPreviewLayer.connection.videoOrientation = [self orientationForConnection:false];
         }
         
         // add audio if video is enabled
@@ -313,7 +314,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     
     // get connection and set orientation
     AVCaptureConnection *videoConnection = [self captureConnection];
-    videoConnection.videoOrientation = [self orientationForConnection];
+    videoConnection.videoOrientation = [self orientationForConnection:true];
     
     // freeze the screen
     [self.captureVideoPreviewLayer.connection setEnabled:NO];
@@ -382,7 +383,7 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
             // get only the video media types
             if ([[port mediaType] isEqual:AVMediaTypeVideo]) {
                 if([connection isVideoOrientationSupported]) {
-                    [connection setVideoOrientation:[self orientationForConnection]];
+                    [connection setVideoOrientation:[self orientationForConnection:false]];
                 }
             }
         }
@@ -846,14 +847,14 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     self.captureVideoPreviewLayer.bounds = bounds;
     self.captureVideoPreviewLayer.position = CGPointMake(CGRectGetMidX(bounds), CGRectGetMidY(bounds));
     
-    self.captureVideoPreviewLayer.connection.videoOrientation = [self orientationForConnection];
+    self.captureVideoPreviewLayer.connection.videoOrientation = [self orientationForConnection:false];
 }
 
-- (AVCaptureVideoOrientation)orientationForConnection
+- (AVCaptureVideoOrientation)orientationForConnection: (BOOL) capture
 {
     AVCaptureVideoOrientation videoOrientation = AVCaptureVideoOrientationPortrait;
     
-    if(self.useDeviceOrientation) {
+    if(self.useDeviceOrientation || (self.useDeviceOrientationOnCapture && capture)) {
         switch ([UIDevice currentDevice].orientation) {
             case UIDeviceOrientationLandscapeLeft:
                 // yes we to the right, this is not bug!


### PR DESCRIPTION
Added a flag to use device orientation on capture. My app currently doesn't support rotation, but I needed the device orientation only on capture, to fix image rotation later. Plus, solved some memory leaks.
