### PR TITLE
Custom tap to focus gesture

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -216,6 +216,11 @@ typedef enum : NSUInteger {
 - (void)alterFocusBox:(CALayer *)layer animation:(CAAnimation *)animation;
 
 /**
+ * Call this method in case you need to implement a custom tap to focus gesture
+ */
+- (void) focusViewOnPoint: (CGPoint) point;
+
+/**
  * Checks is the front camera is available.
  */
 + (BOOL)isFrontCameraAvailable;

--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -218,7 +218,7 @@ typedef enum : NSUInteger {
 /**
  * Call this method in case you need to implement a custom tap to focus gesture
  */
-- (void) focusViewOnPoint: (CGPoint) point;
+- (void) focusViewWithGesture: (UITapGestureRecognizer *) gesture;
 
 /**
  * Checks is the front camera is available.

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -749,12 +749,12 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     }
 }
 
-- (void) focusViewOnPoint: (CGPoint) point {
-    if (!self.tapToFocus) {
-        return;
-    }
+- (void) focusViewWithGesture: (UITapGestureRecognizer *) gesture {
+    CGPoint touchedPoint = [gesture locationInView:self.view];
     
-    [self showFocusBox:point];
+    if (CGRectContainsPoint(self.view.frame, touchedPoint)) {
+        [self previewTapped:gesture];
+    }
 }
 
 #pragma mark - UIViewController

--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -749,6 +749,14 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
     }
 }
 
+- (void) focusViewOnPoint: (CGPoint) point {
+    if (!self.tapToFocus) {
+        return;
+    }
+    
+    [self showFocusBox:point];
+}
+
 #pragma mark - UIViewController
 
 - (void)viewWillAppear:(BOOL)animated


### PR DESCRIPTION
As the basic function of the framework is to add the camera view on top of everything, sometimes the developer needs to call a `[self.view bringSubviewToFront: contentView]` in order to get their camera buttons or custom views on top, this sometimes can interfere with the **focus to tap** gesture implemented by default.

I added a method called `focusViewWithGesture` which basically sends the implemented gesture recognizer, tests if it's inside the preview view's frame and in case this is positive, then sends the data to previewTapped.