### PR TITLE
Freeze the screen AFTER the capture call to eliminate the occasional…

### DIFF
--- a/LLSimpleCamera/LLSimpleCamera.m
+++ b/LLSimpleCamera/LLSimpleCamera.m
@@ -342,7 +342,10 @@ NSString *const LLSimpleCameraErrorDomain = @"LLSimpleCameraErrorDomain";
                 onCapture(self, image, metadata, error);
              });
          }
-     }];
+     }];    
+
+    // Freeze the screen AFTER the capture call to eliminate the occasional dark image
+    [self.captureVideoPreviewLayer.connection setEnabled:NO];
 }
 
 -(void)capture:(void (^)(LLSimpleCamera *camera, UIImage *image, NSDictionary *metadata, NSError *error))onCapture exactSeenImage:(BOOL)exactSeenImage {


### PR DESCRIPTION
I added the change proposed by @bfichter  in #83 

This should fix #83