### PR TITLE
Add support for Carthage

### DIFF
--- a/LLSimpleCamera.podspec
+++ b/LLSimpleCamera.podspec
@@ -17,6 +17,7 @@ hides the nitty gritty details from the developer
   s.platform     = :ios,'7.0'
   s.source       = { :git => "https://github.com/omergul123/LLSimpleCamera.git", :tag => "v5.0.0" }
   s.source_files  = 'LLSimpleCamera/*.{h,m}'
+  s.exclude_files = 'LLSimpleCamera/Version.h'
   s.requires_arc = true
   s.framework = 'AVFoundation'
 end

--- a/LLSimpleCamera.xcodeproj/project.pbxproj
+++ b/LLSimpleCamera.xcodeproj/project.pbxproj
@@ -265,9 +265,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 5.0.0;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LLSimpleCamera/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -282,9 +283,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
+				CURRENT_PROJECT_VERSION = 5.0.0;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 5;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LLSimpleCamera/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/LLSimpleCamera.xcodeproj/project.pbxproj
+++ b/LLSimpleCamera.xcodeproj/project.pbxproj
@@ -1,0 +1,322 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		03C680D91E010CD10052400F /* LLSimpleCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C680D71E010CD10052400F /* LLSimpleCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		03C680E41E010D990052400F /* LLSimpleCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 03C680DF1E010D990052400F /* LLSimpleCamera.m */; };
+		03C680E51E010D990052400F /* LLSimpleCamera+Helper.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C680E01E010D990052400F /* LLSimpleCamera+Helper.h */; };
+		03C680E61E010D990052400F /* LLSimpleCamera+Helper.m in Sources */ = {isa = PBXBuildFile; fileRef = 03C680E11E010D990052400F /* LLSimpleCamera+Helper.m */; };
+		03C680E71E010D990052400F /* UIImage+FixOrientation.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C680E21E010D990052400F /* UIImage+FixOrientation.h */; };
+		03C680E81E010D990052400F /* UIImage+FixOrientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 03C680E31E010D990052400F /* UIImage+FixOrientation.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		03C680D41E010CD10052400F /* LLSimpleCamera.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LLSimpleCamera.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		03C680D71E010CD10052400F /* LLSimpleCamera.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LLSimpleCamera.h; sourceTree = "<group>"; };
+		03C680D81E010CD10052400F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		03C680DF1E010D990052400F /* LLSimpleCamera.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LLSimpleCamera.m; sourceTree = "<group>"; };
+		03C680E01E010D990052400F /* LLSimpleCamera+Helper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "LLSimpleCamera+Helper.h"; sourceTree = "<group>"; };
+		03C680E11E010D990052400F /* LLSimpleCamera+Helper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "LLSimpleCamera+Helper.m"; sourceTree = "<group>"; };
+		03C680E21E010D990052400F /* UIImage+FixOrientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIImage+FixOrientation.h"; sourceTree = "<group>"; };
+		03C680E31E010D990052400F /* UIImage+FixOrientation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIImage+FixOrientation.m"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		03C680D01E010CD10052400F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		03C680CA1E010CD10052400F = {
+			isa = PBXGroup;
+			children = (
+				03C680D61E010CD10052400F /* LLSimpleCamera */,
+				03C680D51E010CD10052400F /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		03C680D51E010CD10052400F /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				03C680D41E010CD10052400F /* LLSimpleCamera.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		03C680D61E010CD10052400F /* LLSimpleCamera */ = {
+			isa = PBXGroup;
+			children = (
+				03C680E21E010D990052400F /* UIImage+FixOrientation.h */,
+				03C680E31E010D990052400F /* UIImage+FixOrientation.m */,
+				03C680D71E010CD10052400F /* LLSimpleCamera.h */,
+				03C680DF1E010D990052400F /* LLSimpleCamera.m */,
+				03C680E01E010D990052400F /* LLSimpleCamera+Helper.h */,
+				03C680E11E010D990052400F /* LLSimpleCamera+Helper.m */,
+				03C680E91E010DEC0052400F /* Supporting Files */,
+			);
+			path = LLSimpleCamera;
+			sourceTree = "<group>";
+		};
+		03C680E91E010DEC0052400F /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				03C680D81E010CD10052400F /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		03C680D11E010CD10052400F /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03C680E71E010D990052400F /* UIImage+FixOrientation.h in Headers */,
+				03C680D91E010CD10052400F /* LLSimpleCamera.h in Headers */,
+				03C680E51E010D990052400F /* LLSimpleCamera+Helper.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		03C680D31E010CD10052400F /* LLSimpleCamera */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03C680DC1E010CD10052400F /* Build configuration list for PBXNativeTarget "LLSimpleCamera" */;
+			buildPhases = (
+				03C680CF1E010CD10052400F /* Sources */,
+				03C680D01E010CD10052400F /* Frameworks */,
+				03C680D11E010CD10052400F /* Headers */,
+				03C680D21E010CD10052400F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = LLSimpleCamera;
+			productName = LLSimpleCamera;
+			productReference = 03C680D41E010CD10052400F /* LLSimpleCamera.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		03C680CB1E010CD10052400F /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0820;
+				ORGANIZATIONNAME = "Ömer Faruk Gül";
+				TargetAttributes = {
+					03C680D31E010CD10052400F = {
+						CreatedOnToolsVersion = 8.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 03C680CE1E010CD10052400F /* Build configuration list for PBXProject "LLSimpleCamera" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 03C680CA1E010CD10052400F;
+			productRefGroup = 03C680D51E010CD10052400F /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				03C680D31E010CD10052400F /* LLSimpleCamera */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		03C680D21E010CD10052400F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		03C680CF1E010CD10052400F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03C680E61E010D990052400F /* LLSimpleCamera+Helper.m in Sources */,
+				03C680E81E010D990052400F /* UIImage+FixOrientation.m in Sources */,
+				03C680E41E010D990052400F /* LLSimpleCamera.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		03C680DA1E010CD10052400F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		03C680DB1E010CD10052400F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		03C680DD1E010CD10052400F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = LLSimpleCamera/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.omerfarukgul.LLSimpleCamera;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		03C680DE1E010CD10052400F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = LLSimpleCamera/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.omerfarukgul.LLSimpleCamera;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		03C680CE1E010CD10052400F /* Build configuration list for PBXProject "LLSimpleCamera" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03C680DA1E010CD10052400F /* Debug */,
+				03C680DB1E010CD10052400F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		03C680DC1E010CD10052400F /* Build configuration list for PBXNativeTarget "LLSimpleCamera" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03C680DD1E010CD10052400F /* Debug */,
+				03C680DE1E010CD10052400F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 03C680CB1E010CD10052400F /* Project object */;
+}

--- a/LLSimpleCamera.xcodeproj/project.pbxproj
+++ b/LLSimpleCamera.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03144F251E07950A009D7582 /* Version.h in Headers */ = {isa = PBXBuildFile; fileRef = 03144F231E079217009D7582 /* Version.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03C680D91E010CD10052400F /* LLSimpleCamera.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C680D71E010CD10052400F /* LLSimpleCamera.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		03C680E41E010D990052400F /* LLSimpleCamera.m in Sources */ = {isa = PBXBuildFile; fileRef = 03C680DF1E010D990052400F /* LLSimpleCamera.m */; };
 		03C680E51E010D990052400F /* LLSimpleCamera+Helper.h in Headers */ = {isa = PBXBuildFile; fileRef = 03C680E01E010D990052400F /* LLSimpleCamera+Helper.h */; };
@@ -16,6 +17,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		03144F231E079217009D7582 /* Version.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Version.h; sourceTree = "<group>"; };
+		03144F241E07925B009D7582 /* module.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; path = module.modulemap; sourceTree = "<group>"; };
 		03C680D41E010CD10052400F /* LLSimpleCamera.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = LLSimpleCamera.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		03C680D71E010CD10052400F /* LLSimpleCamera.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LLSimpleCamera.h; sourceTree = "<group>"; };
 		03C680D81E010CD10052400F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -58,6 +61,7 @@
 			children = (
 				03C680E21E010D990052400F /* UIImage+FixOrientation.h */,
 				03C680E31E010D990052400F /* UIImage+FixOrientation.m */,
+				03144F231E079217009D7582 /* Version.h */,
 				03C680D71E010CD10052400F /* LLSimpleCamera.h */,
 				03C680DF1E010D990052400F /* LLSimpleCamera.m */,
 				03C680E01E010D990052400F /* LLSimpleCamera+Helper.h */,
@@ -71,6 +75,7 @@
 			isa = PBXGroup;
 			children = (
 				03C680D81E010CD10052400F /* Info.plist */,
+				03144F241E07925B009D7582 /* module.modulemap */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -82,8 +87,9 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				03C680E71E010D990052400F /* UIImage+FixOrientation.h in Headers */,
 				03C680D91E010CD10052400F /* LLSimpleCamera.h in Headers */,
+				03C680E71E010D990052400F /* UIImage+FixOrientation.h in Headers */,
+				03144F251E07950A009D7582 /* Version.h in Headers */,
 				03C680E51E010D990052400F /* LLSimpleCamera+Helper.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -273,6 +279,7 @@
 				INFOPLIST_FILE = LLSimpleCamera/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/LLSimpleCamera/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.omerfarukgul.LLSimpleCamera;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -291,6 +298,7 @@
 				INFOPLIST_FILE = LLSimpleCamera/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "$(SRCROOT)/LLSimpleCamera/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.omerfarukgul.LLSimpleCamera;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/LLSimpleCamera.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/LLSimpleCamera.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:LLSimpleCamera.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/LLSimpleCamera.xcodeproj/xcshareddata/xcschemes/LLSimpleCamera.xcscheme
+++ b/LLSimpleCamera.xcodeproj/xcshareddata/xcschemes/LLSimpleCamera.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0820"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "03C680D31E010CD10052400F"
+               BuildableName = "LLSimpleCamera.framework"
+               BlueprintName = "LLSimpleCamera"
+               ReferencedContainer = "container:LLSimpleCamera.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C680D31E010CD10052400F"
+            BuildableName = "LLSimpleCamera.framework"
+            BlueprintName = "LLSimpleCamera"
+            ReferencedContainer = "container:LLSimpleCamera.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "03C680D31E010CD10052400F"
+            BuildableName = "LLSimpleCamera.framework"
+            BlueprintName = "LLSimpleCamera"
+            ReferencedContainer = "container:LLSimpleCamera.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/LLSimpleCamera/Info.plist
+++ b/LLSimpleCamera/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -9,6 +9,12 @@
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
 
+//! Project version number for LLSimpleCamera.
+FOUNDATION_EXPORT double LLSimpleCameraVersionNumber;
+
+//! Project version string for LLSimpleCamera.
+FOUNDATION_EXPORT const unsigned char LLSimpleCameraVersionString[];
+
 typedef enum : NSUInteger {
     LLCameraPositionRear,
     LLCameraPositionFront

--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -9,12 +9,6 @@
 #import <UIKit/UIKit.h>
 #import <AVFoundation/AVFoundation.h>
 
-//! Project version number for LLSimpleCamera.
-FOUNDATION_EXPORT double LLSimpleCameraVersionNumber;
-
-//! Project version string for LLSimpleCamera.
-FOUNDATION_EXPORT const unsigned char LLSimpleCameraVersionString[];
-
 typedef enum : NSUInteger {
     LLCameraPositionRear,
     LLCameraPositionFront

--- a/LLSimpleCamera/LLSimpleCamera.h
+++ b/LLSimpleCamera/LLSimpleCamera.h
@@ -140,7 +140,7 @@ typedef enum : NSUInteger {
 
 /**
  * Returns an instance of LLSimpleCamera with quality "AVCaptureSessionPresetHigh" and position "CameraPositionBack".
- * @param videEnabled: Set to YES to enable video recording.
+ * @param videoEnabled Set to YES to enable video recording.
  */
 - (instancetype)initWithVideoEnabled:(BOOL)videoEnabled;
 

--- a/LLSimpleCamera/Version.h
+++ b/LLSimpleCamera/Version.h
@@ -1,0 +1,14 @@
+//
+//  Version.h
+//  LLSimpleCamera
+//
+//  Copyright © 2016 Ömer Faruk Gül. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for LLSimpleCamera.
+FOUNDATION_EXPORT double LLSimpleCameraVersionNumber;
+
+//! Project version string for LLSimpleCamera.
+FOUNDATION_EXPORT const unsigned char LLSimpleCameraVersionString[];

--- a/LLSimpleCamera/module.modulemap
+++ b/LLSimpleCamera/module.modulemap
@@ -1,0 +1,4 @@
+framework module LLSimpleCamera {
+    header "LLSimpleCamera.h"
+    header "Version.h"
+}


### PR DESCRIPTION
This PR adds a project (`LLSimpleCamera.xcproj`) that allows building the library as a dynamic framework. This allows `LLSimpleCamera` to be compatible with the [Carthage dependency manager](https://github.com/Carthage/Carthage).

The version exports have been placed in a separate file; this allows them to be excluded from the podspec, where it will not be built as a framework and version exports are unavailable.