### PR TITLE
Added `NSCameraUsageDescription` key to Info.plist as now required.

### DIFF
--- a/LLSimpleCameraExample/Info.plist
+++ b/LLSimpleCameraExample/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSCameraUsageDescription</key>
 	<string>LLSimpleCameraExample needs to use the camera.</string>	
+	<key>NSMicrophoneUsageDescription</key>
+        <string>LLSimpleCameraExample needs to use the microphone.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/LLSimpleCameraExample/Info.plist
+++ b/LLSimpleCameraExample/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCameraUsageDescription</key>
+	<string>LLSimpleCameraExample needs to use the camera.</string>	
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>


### PR DESCRIPTION
Without this key, the following error is returned at runtime: 

    2017-04-24 15:09:24.660704-0600 LLSimpleCameraExample[233:5830] [access] This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSCameraUsageDescription key with a string value explaining to the user how the app uses this data.